### PR TITLE
SIE-92 Publish stimuli completion msg to pubsub

### DIFF
--- a/stimuli_ci_generation/requirements.txt
+++ b/stimuli_ci_generation/requirements.txt
@@ -17,3 +17,4 @@ urllib3==1.25.9
 Werkzeug==1.0.1
 google-cloud-storage
 google-cloud-logging
+google-cloud-pubsub==2.4.0

--- a/stimuli_ci_generation/src/gcp_config.py
+++ b/stimuli_ci_generation/src/gcp_config.py
@@ -8,3 +8,10 @@ MASKED_IMG_BUCKET = "sie-masked-images"
 STIMULI_IMG_BUCKET = "sie-stimuli-images"
 USER_SELECTION_BUCKET = "sie-user-selections"
 CI_IMG_BUCKET = "sie-ci-images"
+
+
+"""
+    Pubsub topic ids
+"""
+
+SIE_IMG_PROCESSING_RESULT = "sie-image-processing-result-test"

--- a/stimuli_ci_generation/src/gcp_config.py
+++ b/stimuli_ci_generation/src/gcp_config.py
@@ -1,6 +1,11 @@
 #!/usr/bin/python3
 
 """
+    Project level config
+"""
+PROJECT_ID = "cs6510-spr2021"
+
+"""
     Bucket names configured on gcp cloud storage for this project
 """
 RAW_IMG_BUCKET = "sie-raw-images"

--- a/stimuli_ci_generation/src/server/main.py
+++ b/stimuli_ci_generation/src/server/main.py
@@ -7,7 +7,10 @@ import os
 import base64
 import json
 
+from server.pubsub import pub_msg
 from server.stimuli_ci import generate_stimuli, generate_ci
+
+from gcp_config import SIE_IMG_PROCESSING_RESULT
 
 app = Flask(__name__)
 
@@ -63,7 +66,8 @@ def index():
         else:
             try:
                 generate_stimuli(participant_id, file_name)
-                return ("Generating stimuli images...", 202)
+                pub_msg("Stimuli generated", SIE_IMG_PROCESSING_RESULT, participant_id)
+                return ("Stimuli generated", 202)
             except Exception as e:
                 print(e)
                 return ("Failed to generate stimuli", 204)

--- a/stimuli_ci_generation/src/server/main.py
+++ b/stimuli_ci_generation/src/server/main.py
@@ -70,7 +70,7 @@ def index():
             except Exception:
                 return ("Failed to generate ci", 204)
         else:
-            # this is for after participants upload their images 
+            # this is for after participants upload their images
             # and the images pass facial detection
             try:
                 generate_stimuli(participant_id, file_name)

--- a/stimuli_ci_generation/src/server/main.py
+++ b/stimuli_ci_generation/src/server/main.py
@@ -52,9 +52,12 @@ def index():
             print(f"error: {msg}")
             return f"Bad Request: {msg}", 400
 
-        file_identifier = data["name"]  # should be participant_id/neutral.jpg
+        file_identifier = data[
+            "name"
+        ]  # should be participant_id-experiment_id/neutral.jpg
         print("file_identifier:", file_identifier)
-        participant_id, file_name = file_identifier.split("/")
+        user_id, file_name = file_identifier.split("/")
+        participant_id, experiment_id = user_id.split("-")
         file_type = file_name.split(".")[-1]
 
         if file_type.lower() == "csv":
@@ -66,7 +69,12 @@ def index():
         else:
             try:
                 generate_stimuli(participant_id, file_name)
-                pub_msg("Stimuli generated", SIE_IMG_PROCESSING_RESULT, participant_id)
+                pub_msg(
+                    "Completed",
+                    SIE_IMG_PROCESSING_RESULT,
+                    participant_id,
+                    experiment_id,
+                )
                 return ("Stimuli generated", 202)
             except Exception as e:
                 print(e)

--- a/stimuli_ci_generation/src/server/main.py
+++ b/stimuli_ci_generation/src/server/main.py
@@ -60,13 +60,18 @@ def index():
         participant_id, experiment_id = user_id.split("-")
         file_type = file_name.split(".")[-1]
 
+        # returning 2xx here to ack pub/sub msg
+        # or else storage trigger will keep retrying
         if file_type.lower() == "csv":
+            # this is for after participants finishes with their img selections
             try:
                 generate_ci(participant_id, file_name)
                 return ("Generating ci images...", 202)
             except Exception:
                 return ("Failed to generate ci", 204)
         else:
+            # this is for after participants upload their images 
+            # and the images pass facial detection
             try:
                 generate_stimuli(participant_id, file_name)
                 pub_msg(

--- a/stimuli_ci_generation/src/server/pubsub.py
+++ b/stimuli_ci_generation/src/server/pubsub.py
@@ -8,6 +8,7 @@ publisher = pubsub_v1.PublisherClient()
 
 # Configure the retry settings. Defaults shown in comments are values applied
 # by the library by default, instead of default values in the Retry object.
+# doc: https://cloud.google.com/pubsub/docs/publisher
 custom_retry = api_core.retry.Retry(
     initial=0.250,  # seconds (default: 0.1)
     maximum=90.0,  # seconds (default: 60.0)

--- a/stimuli_ci_generation/src/server/pubsub.py
+++ b/stimuli_ci_generation/src/server/pubsub.py
@@ -25,17 +25,32 @@ custom_retry = api_core.retry.Retry(
 )
 
 
-def get_callback(f, data):
-    def callback(f):
+def get_callback(future, data):
+    """
+    Handle callback from msg publishing
+    Args:
+        future: future object
+        data: published message
+    """
+
+    def callback(future):
         try:
-            print(f.result())
+            print(future.result())
         except:  # noqa
-            print("Please handle {} for {}.".format(f.exception(), data))
+            print("Please handle {} for {}.".format(future.exception(), data))
 
     return callback
 
 
 def pub_msg(msg: str, topic_id, participant_id: str):
+    """
+    Publish a message to a pubsub topic
+    Args:
+        msg: message to be published
+        topic_id: pubsub topic id
+        participant_id: participant id
+    """
+
     data = msg.encode("utf-8")
     topic_path = publisher.topic_path(PROJECT_ID, topic_id)
     future = publisher.publish(

--- a/stimuli_ci_generation/src/server/pubsub.py
+++ b/stimuli_ci_generation/src/server/pubsub.py
@@ -1,8 +1,9 @@
 from google.cloud import pubsub_v1
 from google import api_core
 
+from gcp_config import PROJECT_ID
 
-PROJECT_ID = "cs6510-spr2021"
+
 publisher = pubsub_v1.PublisherClient()
 
 
@@ -43,18 +44,23 @@ def get_callback(future, data):
     return callback
 
 
-def pub_msg(msg: str, topic_id, participant_id: str):
+def pub_msg(msg: str, topic_id: str, participant_id: str, experiment_id: str):
     """
     Publish a message to a pubsub topic
     Args:
         msg: message to be published
         topic_id: pubsub topic id
         participant_id: participant id
+        experiment_id: experiment_id
     """
 
     data = msg.encode("utf-8")
     topic_path = publisher.topic_path(PROJECT_ID, topic_id)
     future = publisher.publish(
-        topic_path, data, participant_id=participant_id, retry=custom_retry
+        topic_path,
+        data,
+        participant_id=participant_id,
+        experiment_id=experiment_id,
+        retry=custom_retry,
     )
     future.add_done_callback(get_callback(future, data))

--- a/stimuli_ci_generation/src/server/pubsub.py
+++ b/stimuli_ci_generation/src/server/pubsub.py
@@ -1,0 +1,44 @@
+from google.cloud import pubsub_v1
+from google import api_core
+
+
+PROJECT_ID = "cs6510-spr2021"
+publisher = pubsub_v1.PublisherClient()
+
+
+# Configure the retry settings. Defaults shown in comments are values applied
+# by the library by default, instead of default values in the Retry object.
+custom_retry = api_core.retry.Retry(
+    initial=0.250,  # seconds (default: 0.1)
+    maximum=90.0,  # seconds (default: 60.0)
+    multiplier=1.45,  # default: 1.3
+    deadline=120.0,  # seconds (default: 60.0)
+    predicate=api_core.retry.if_exception_type(
+        api_core.exceptions.Aborted,
+        api_core.exceptions.DeadlineExceeded,
+        api_core.exceptions.InternalServerError,
+        api_core.exceptions.ResourceExhausted,
+        api_core.exceptions.ServiceUnavailable,
+        api_core.exceptions.Unknown,
+        api_core.exceptions.Cancelled,
+    ),
+)
+
+
+def get_callback(f, data):
+    def callback(f):
+        try:
+            print(f.result())
+        except:  # noqa
+            print("Please handle {} for {}.".format(f.exception(), data))
+
+    return callback
+
+
+def pub_msg(msg: str, topic_id, participant_id: str):
+    data = msg.encode("utf-8")
+    topic_path = publisher.topic_path(PROJECT_ID, topic_id)
+    future = publisher.publish(
+        topic_path, data, participant_id=participant_id, retry=custom_retry
+    )
+    future.add_done_callback(get_callback(future, data))

--- a/stimuli_ci_generation/src/server/stimuli_ci.py
+++ b/stimuli_ci_generation/src/server/stimuli_ci.py
@@ -11,24 +11,24 @@ import gcp_config
 USER_SELECTION = "user_selection.csv"
 
 
-def generate_stimuli(participant_id, file_name):
+def generate_stimuli(id, file_name):
     """
     Run stimuli generation and save processed images for experiment
     Args:
-        participant_id: participant_id extracted from img filename
+        id: participant_id-experiment_id extracted from img filename
 
     Returns:
         None
     """
     downloaded_path = download_file(
         gcp_config.MASKED_IMG_BUCKET,
-        f"{participant_id}/{file_name}",
-        f"{mkdir(participant_id)}/{file_name}",
+        f"{id}/{file_name}",
+        f"{mkdir(id)}/{file_name}",
     )
     print("downloaded_to:", downloaded_path)
 
-    output_dir = mkdir(participant_id)
-    stimuli_dir = mkdir(participant_id, "stimuli")
+    output_dir = mkdir(id)
+    stimuli_dir = mkdir(id, "stimuli")
     r_script_path = f"{os.getcwd()}/rscript/generate_stimuli.R"
 
     try:
@@ -36,36 +36,33 @@ def generate_stimuli(participant_id, file_name):
             ["Rscript", "--vanilla", r_script_path, output_dir], shell=False
         )
         print("Finished running generate_stimuli.R")
-        upload_dir(gcp_config.STIMULI_IMG_BUCKET, stimuli_dir, participant_id)
-
-        # TODO: sends message to pub/sub to notify completion of stimuli genetation
-
+        upload_dir(gcp_config.STIMULI_IMG_BUCKET, stimuli_dir, id)
     except subprocess.CalledProcessError as err:
         print("Error running generate_stimuli.R", err)
         raise err
 
 
-def generate_ci(participant_id, file_name):
+def generate_ci(id, file_name):
     """
     Run ci and upload results to cloud storage
     Args:
-        participant_id: participant_id extracted from img filename
+        id: participant_id-experiment_id extracted from img filename
 
     Returns:
         None
     """
-    ws_dir = mkdir(participant_id)
-    ci_dir = mkdir(participant_id, "ci")
+    ws_dir = mkdir(id)
+    ci_dir = mkdir(id, "ci")
     r_script_path = f"{os.getcwd()}/rscript/generate_ci.R"
 
     if not os.path.exists(f"{ws_dir}/stimuli"):
-        mkdir(participant_id, "stimuli")
-        download_dir(gcp_config.STIMULI_IMG_BUCKET, participant_id, f"{ws_dir}/stimuli")
+        mkdir(id, "stimuli")
+        download_dir(gcp_config.STIMULI_IMG_BUCKET, id, f"{ws_dir}/stimuli")
         print(f"downloaded stimuli images to {ws_dir}/stimuli")
 
     download_file(
         gcp_config.USER_SELECTION_BUCKET,
-        f"{participant_id}/{USER_SELECTION}",
+        f"{id}/{USER_SELECTION}",
         f"{ws_dir}/{USER_SELECTION}",
     )
     print(f"user_selection.csv has been downloaded to {ws_dir}/{USER_SELECTION}")
@@ -73,7 +70,7 @@ def generate_ci(participant_id, file_name):
     try:
         subprocess.check_call(["Rscript", r_script_path, ws_dir], shell=False)
         print("Finished running generate_ci.R")
-        upload_dir(gcp_config.CI_IMG_BUCKET, ci_dir, participant_id)
+        upload_dir(gcp_config.CI_IMG_BUCKET, ci_dir, id)
     except subprocess.CalledProcessError as err:
         print("Error running generate_ci.R", err)
         raise err

--- a/stimuli_ci_generation/src/server/stimuli_ci.py
+++ b/stimuli_ci_generation/src/server/stimuli_ci.py
@@ -11,24 +11,24 @@ import gcp_config
 USER_SELECTION = "user_selection.csv"
 
 
-def generate_stimuli(id, file_name):
+def generate_stimuli(identifier, file_name):
     """
     Run stimuli generation and save processed images for experiment
     Args:
-        id: participant_id-experiment_id extracted from img filename
+        identifier: participant_id-experiment_id extracted from img filename
 
     Returns:
         None
     """
     downloaded_path = download_file(
         gcp_config.MASKED_IMG_BUCKET,
-        f"{id}/{file_name}",
-        f"{mkdir(id)}/{file_name}",
+        f"{identifier}/{file_name}",
+        f"{mkdir(identifier)}/{file_name}",
     )
     print("downloaded_to:", downloaded_path)
 
-    output_dir = mkdir(id)
-    stimuli_dir = mkdir(id, "stimuli")
+    output_dir = mkdir(identifier)
+    stimuli_dir = mkdir(identifier, "stimuli")
     r_script_path = f"{os.getcwd()}/rscript/generate_stimuli.R"
 
     try:
@@ -36,28 +36,28 @@ def generate_stimuli(id, file_name):
             ["Rscript", "--vanilla", r_script_path, output_dir], shell=False
         )
         print("Finished running generate_stimuli.R")
-        upload_dir(gcp_config.STIMULI_IMG_BUCKET, stimuli_dir, id)
+        upload_dir(gcp_config.STIMULI_IMG_BUCKET, stimuli_dir, identifier)
     except subprocess.CalledProcessError as err:
         print("Error running generate_stimuli.R", err)
         raise err
 
 
-def generate_ci(id, file_name):
+def generate_ci(identifier, file_name):
     """
     Run ci and upload results to cloud storage
     Args:
-        id: participant_id-experiment_id extracted from img filename
+        identifier: participant_id-experiment_id extracted from img filename
 
     Returns:
         None
     """
-    ws_dir = mkdir(id)
-    ci_dir = mkdir(id, "ci")
+    ws_dir = mkdir(identifier)
+    ci_dir = mkdir(identifier, "ci")
     r_script_path = f"{os.getcwd()}/rscript/generate_ci.R"
 
     if not os.path.exists(f"{ws_dir}/stimuli"):
-        mkdir(id, "stimuli")
-        download_dir(gcp_config.STIMULI_IMG_BUCKET, id, f"{ws_dir}/stimuli")
+        mkdir(identifier, "stimuli")
+        download_dir(gcp_config.STIMULI_IMG_BUCKET, identifier, f"{ws_dir}/stimuli")
         print(f"downloaded stimuli images to {ws_dir}/stimuli")
 
     download_file(
@@ -70,7 +70,7 @@ def generate_ci(id, file_name):
     try:
         subprocess.check_call(["Rscript", r_script_path, ws_dir], shell=False)
         print("Finished running generate_ci.R")
-        upload_dir(gcp_config.CI_IMG_BUCKET, ci_dir, id)
+        upload_dir(gcp_config.CI_IMG_BUCKET, ci_dir, identifier)
     except subprocess.CalledProcessError as err:
         print("Error running generate_ci.R", err)
         raise err

--- a/stimuli_ci_generation/src/server/stimuli_ci.py
+++ b/stimuli_ci_generation/src/server/stimuli_ci.py
@@ -6,7 +6,7 @@ import os
 from server.gcp_cloud_storage import upload_dir, download_file, download_dir
 from server.util import mkdir
 
-import bucket_config
+import gcp_config
 
 USER_SELECTION = "user_selection.csv"
 
@@ -21,7 +21,7 @@ def generate_stimuli(participant_id, file_name):
         None
     """
     downloaded_path = download_file(
-        bucket_config.MASKED_IMG_BUCKET,
+        gcp_config.MASKED_IMG_BUCKET,
         f"{participant_id}/{file_name}",
         f"{mkdir(participant_id)}/{file_name}",
     )
@@ -36,7 +36,7 @@ def generate_stimuli(participant_id, file_name):
             ["Rscript", "--vanilla", r_script_path, output_dir], shell=False
         )
         print("Finished running generate_stimuli.R")
-        upload_dir(bucket_config.STIMULI_IMG_BUCKET, stimuli_dir, participant_id)
+        upload_dir(gcp_config.STIMULI_IMG_BUCKET, stimuli_dir, participant_id)
 
         # TODO: sends message to pub/sub to notify completion of stimuli genetation
 
@@ -61,12 +61,12 @@ def generate_ci(participant_id, file_name):
     if not os.path.exists(f"{ws_dir}/stimuli"):
         mkdir(participant_id, "stimuli")
         download_dir(
-            bucket_config.STIMULI_IMG_BUCKET, participant_id, f"{ws_dir}/stimuli"
+            gcp_config.STIMULI_IMG_BUCKET, participant_id, f"{ws_dir}/stimuli"
         )
         print(f"downloaded stimuli images to {ws_dir}/stimuli")
 
     download_file(
-        bucket_config.USER_SELECTION_BUCKET,
+        gcp_config.USER_SELECTION_BUCKET,
         f"{participant_id}/{USER_SELECTION}",
         f"{ws_dir}/{USER_SELECTION}",
     )
@@ -75,7 +75,7 @@ def generate_ci(participant_id, file_name):
     try:
         subprocess.check_call(["Rscript", r_script_path, ws_dir], shell=False)
         print("Finished running generate_ci.R")
-        upload_dir(bucket_config.CI_IMG_BUCKET, ci_dir, participant_id)
+        upload_dir(gcp_config.CI_IMG_BUCKET, ci_dir, participant_id)
     except subprocess.CalledProcessError as err:
         print("Error running generate_ci.R", err)
         raise err

--- a/stimuli_ci_generation/src/server/stimuli_ci.py
+++ b/stimuli_ci_generation/src/server/stimuli_ci.py
@@ -60,9 +60,7 @@ def generate_ci(participant_id, file_name):
 
     if not os.path.exists(f"{ws_dir}/stimuli"):
         mkdir(participant_id, "stimuli")
-        download_dir(
-            gcp_config.STIMULI_IMG_BUCKET, participant_id, f"{ws_dir}/stimuli"
-        )
+        download_dir(gcp_config.STIMULI_IMG_BUCKET, participant_id, f"{ws_dir}/stimuli")
         print(f"downloaded stimuli images to {ws_dir}/stimuli")
 
     download_file(


### PR DESCRIPTION
I implemented pubsub to send completion msg after stimuli has been generated.

I renamed `bucket_config` to `gcp_config` to include other GCP resources as well.

EDIT: we had a discussion on image/message naming and here is a recap:
- image format: `participant_id-experiment_id.jpg`
- stimuli completion message is a json object w/ status `Completed` and `participant_id` and `experiment_id` attributes