### PR TITLE
SIE-170 Face exception to firebase

### DIFF
--- a/face_detection_masking/firestore.py
+++ b/face_detection_masking/firestore.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""
+This module contains helper methods to modify firestore documents
+"""
+
+from google.cloud import firestore
+
+FIRESTORE_USER_COLLECTION = "Users"
+db = firestore.Client()
+
+
+def update_user_doc(participant_id, experiment_id, stimuli_status):
+    """
+    Update a firestore user document with corresponding attributes.
+    The purpose of this function is to let the frontend team know
+    about any InvalidFaceImage exception messages.
+    Args:
+        participant_id: user's uid
+        experiment_id: experiment's id
+        stimuli_status: 'error message'
+    Returns:
+        None
+    """
+    user_doc_ref = db.collection(FIRESTORE_USER_COLLECTION).document(participant_id)
+    user_doc_ref.update({"sie_stimuli_generation_status": stimuli_status})

--- a/face_detection_masking/firestore.py
+++ b/face_detection_masking/firestore.py
@@ -10,7 +10,7 @@ FIRESTORE_USER_COLLECTION = "Users"
 db = firestore.Client()
 
 
-def update_user_doc(participant_id, experiment_id, stimuli_status):
+def update_user_doc(participant_id, experiment_id, error_message):
     """
     Update a firestore user document with corresponding attributes.
     The purpose of this function is to let the frontend team know
@@ -18,9 +18,9 @@ def update_user_doc(participant_id, experiment_id, stimuli_status):
     Args:
         participant_id: user's uid
         experiment_id: experiment's id
-        stimuli_status: 'error message'
+        error_message: 'error message'
     Returns:
         None
     """
     user_doc_ref = db.collection(FIRESTORE_USER_COLLECTION).document(participant_id)
-    user_doc_ref.update({"sie_stimuli_generation_status": stimuli_status})
+    user_doc_ref.update({"sie_stimuli_generation_status": error_message})

--- a/face_detection_masking/requirements.txt
+++ b/face_detection_masking/requirements.txt
@@ -5,3 +5,4 @@ google-cloud-vision==2.2.0
 opencv-python==4.3.0.38
 numpy==1.19.1
 pytest==6.2.2
+google-cloud-firestore


### PR DESCRIPTION
This PR adds functionality to push invalid face image message to Firestore. The exception message is added to the `sie_stimuli_generation_status`  field in Users collection.

How to test:
- Upload an invalid image with the filename _"$PARTICIPANT_ID-$EXPERIMENT-ID.jpg"_ to `sie-raw-images` bucket. 
- Check for the exception message in Users collection for that particular participant in Firestore