### PR TITLE
SIE-176 Refactored update_user_doc in image processing pipeline

### DIFF
--- a/qualtrics_server/firestore.py
+++ b/qualtrics_server/firestore.py
@@ -6,7 +6,10 @@ This module contains helper methods to modify firestore documents
 
 
 from google.cloud import firestore
-from gcp_config import FIRESTORE_USER_COLLECTION, FIRESTORE_USER_EXPERIMENT_COLLECTION
+from gcp_config import (
+    FIRESTORE_USER_COLLECTION,
+    FIRESTORE_USER_EXPERIMENT_SUBCOLLECTION,
+)
 
 db = firestore.Client()
 
@@ -25,7 +28,7 @@ def update_user_doc(participant_id: str, experiment_id: str, attributes: dict):
     user_doc_ref = db.collection(
         f"{FIRESTORE_USER_COLLECTION}/"
         f"{participant_id}/"
-        f"{FIRESTORE_USER_EXPERIMENT_COLLECTION}"
+        f"{FIRESTORE_USER_EXPERIMENT_SUBCOLLECTION}"
     ).document(experiment_id)
 
     if attributes:

--- a/qualtrics_server/gcp_config.py
+++ b/qualtrics_server/gcp_config.py
@@ -10,4 +10,4 @@ PROJECT_ID = "cs6510-spr2021"
 """
 FIRESTORE_USER_COLLECTION = "Users"
 # a sub-collection in a user document
-FIRESTORE_USER_EXPERIMENT_COLLECTION = "Experiments"
+FIRESTORE_USER_EXPERIMENT_SUBCOLLECTION = "Experiments"

--- a/stimuli_ci_generation/src/gcp_config.py
+++ b/stimuli_ci_generation/src/gcp_config.py
@@ -26,3 +26,4 @@ SIE_IMG_PROCESSING_RESULT = "sie-image-processing-result-test"
     Firestore collections
 """
 FIRESTORE_USER_COLLECTION = "Users"
+FIRESTORE_USER_EXPERIMENT_SUBCOLLECTION = "Experiments"

--- a/stimuli_ci_generation/src/server/firestore.py
+++ b/stimuli_ci_generation/src/server/firestore.py
@@ -5,20 +5,31 @@ This module contains helper methods to modify firestore documents
 """
 
 from google.cloud import firestore
-from gcp_config import FIRESTORE_USER_COLLECTION
+from gcp_config import (
+    FIRESTORE_USER_COLLECTION,
+    FIRESTORE_USER_EXPERIMENT_SUBCOLLECTION,
+)
 
 db = firestore.Client()
 
 
-def update_user_doc(participant_id, experiment_id, stimuli_status=None):
+def update_user_doc(participant_id: str, experiment_id: str, attributes: dict):
     """
     Update a firestore user document with corresponding attributes
     Args:
         participant_id: user's uid
         experiment_id: experiment's id
-        stimuli_status: 'completed' or None
+        attributes: dict of qualtrics responses
     Returns:
         None
     """
-    user_doc_ref = db.collection(FIRESTORE_USER_COLLECTION).document(participant_id)
-    user_doc_ref.update({"sie_stimuli_generation_status": stimuli_status or ""})
+
+    user_doc_ref = db.collection(
+        f"{FIRESTORE_USER_COLLECTION}/"
+        f"{participant_id}/"
+        f"{FIRESTORE_USER_EXPERIMENT_SUBCOLLECTION}"
+    ).document(experiment_id)
+
+    if attributes:
+        # update if exists, otherwise create a new doc
+        user_doc_ref.set(attributes, merge=True)

--- a/stimuli_ci_generation/src/server/firestore.py
+++ b/stimuli_ci_generation/src/server/firestore.py
@@ -19,7 +19,7 @@ def update_user_doc(participant_id: str, experiment_id: str, attributes: dict):
     Args:
         participant_id: user's uid
         experiment_id: experiment's id
-        attributes: dict of qualtrics responses
+        attributes: dict of doc attributes to update
     Returns:
         None
     """

--- a/stimuli_ci_generation/src/server/main.py
+++ b/stimuli_ci_generation/src/server/main.py
@@ -80,11 +80,20 @@ def index():
             # and the images pass facial detection
             try:
                 generate_stimuli(identifier, file_name)
-                update_user_doc(participant_id, experiment_id, "completed")
+                update_user_doc(
+                    participant_id,
+                    experiment_id,
+                    {"sie_stimuli_generation_status": "completed"},
+                )
 
                 return ("Stimuli generated", 202)
             except Exception as e:
                 print(e)
+                update_user_doc(
+                    participant_id,
+                    experiment_id,
+                    {"sie_stimuli_generation_status": "incomplete"},
+                )
                 return ("Failed to generate stimuli", 204)
 
     print("data missing in pub/sub message")


### PR DESCRIPTION
**What's in this PR?**
- Refactored image processing pipeline: specifically changing how the pipeline modifies user doc to signal stimuli generation completion
- The new design is to modify `Users/user_uid/Experiments/experiment_id` document

**Test**
- I manually tested this. To test this yourself, upload an image named `user_id-experiment_id.jpg` to our raw image bucket and check the corresponding user doc in firestore.